### PR TITLE
fix: エラーレスポンスを構造化してAIクライアントに返すように改善

### DIFF
--- a/src/errors/custom-errors.ts
+++ b/src/errors/custom-errors.ts
@@ -5,7 +5,7 @@
 /**
  * Base error class for all custom errors
  */
-class N8nMcpError extends Error {
+export class N8nMcpError extends Error {
   constructor(
     message: string,
     public readonly context?: Record<string, unknown>,


### PR DESCRIPTION
## 概要
n8n-mcp-serverのエラーハンドリングを改善し、エラー情報を構造化してAIクライアントに返すようにしました。

## 変更内容
- `N8nMcpError`クラスをexportして外部から利用可能に
- `BaseTool.handler()`のエラーハンドリングを改善
  - error.contextがある場合はそれを優先的にレスポンスとして返す
  - contextがない場合はエラーオブジェクト全体を返す
- エラー情報をJSON形式で構造化して返すことで、AIがエラー内容を適切に理解できるように

## 動作確認
以下のエラーケースですべて正しくエラー情報が返されることを確認済み：

### ワークフロー管理ツール
- ✅ 存在しないワークフローIDへのアクセス → Not Foundエラー
- ✅ 無効なノード構造での更新 → Zodバリデーションエラー
- ✅ 必須フィールド不足 → Zodバリデーションエラー
- ✅ 存在しないファイルからの作成 → FileErrorエラー
- ✅ 無効なJSONファイル → FileErrorエラー

### 実行管理ツール
- ✅ 無効なステータス値 → Zodバリデーションエラー
- ✅ 存在しない実行ID → Not Foundエラー
- ✅ 無効なID形式 → Zodバリデーションエラー
- ✅ 存在しないノード名 → エラーレスポンス

## エラーレスポンスの種類
1. **Zodバリデーションエラー**: `MCP error -32602` + 詳細なフィールドエラー
2. **n8n APIエラー**: 構造化JSON（operation, resourceType, resourceId, errorDetails）
3. **ファイルエラー**: FileError + filePath

🤖 Generated with [Claude Code](https://claude.com/claude-code)